### PR TITLE
change order so we actually get java opts

### DIFF
--- a/templates/default/sv-artifactory-run.erb
+++ b/templates/default/sv-artifactory-run.erb
@@ -7,9 +7,11 @@ export TOMCAT_HOME=/usr/local/artifactory/tomcat
 export ARTIFACTORY_HOME=<%= node["artifactory"]["home"] %>
 export ARTIFACTORY_PID=$ARTIFACTORY_HOME/run/artifactory.pid
 export CATALINA_BASE=<%= node["artifactory"]["catalina_base"] %>
-export CATALINA_OPTS="$JAVA_OPTIONS -Dartifactory.home=$ARTIFACTORY_HOME -Dfile.encoding=UTF8"
 
 export JAVA_OPTIONS="-server -Xmx<%= node["artifactory"]["java"]["xmx"] %> -Xms<%= node["artifactory"]["java"]["xms"] %> -Xss256k -XX:PermSize=128m -XX:MaxPermSize=128m <%= node["artifactory"]["java"]["extra_opts"] %>"
+
+export CATALINA_OPTS="$JAVA_OPTIONS -Dartifactory.home=$ARTIFACTORY_HOME -Dfile.encoding=UTF8"
+
 
 [ -x $TOMCAT_HOME/bin/catalina.sh ] || chmod +x $TOMCAT_HOME/bin/*.sh
 


### PR DESCRIPTION
CATALINA_OPTS isn't getting the JAVA_OPTIONS flag for runit, so they aren't actually getting passed in. I believe arti is starting with default java options. 