### PR TITLE
Add ownership for directories.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,6 +9,7 @@ default['artifactory']['java']['extra_opts'] = '-XX:+UseG1GC'
 default['artifactory']['java']['jdk_version'] = 8
 
 default['artifactory']['user'] = 'artifactory'
+default['artifactory']['group'] = 'artifactory'
 default['artifactory']['port'] = 8081
 default['artifactory']['shutdown_port'] = 8015
 default['artifactory']['install_java'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,14 +21,20 @@ user node['artifactory']['user'] do
   home node['artifactory']['home']
 end
 
+group node['artifactory']['group'] do
+  members [node['artifactory']['user']]
+end
+
 directory node['artifactory']['home'] do
   owner node['artifactory']['user']
+  group node['artifactory']['group']
   mode 00755
   recursive true
 end
 
 directory node['artifactory']['catalina_base'] do
   owner node['artifactory']['user']
+  group node['artifactory']['group']
   mode 00755
   recursive true
 end
@@ -36,18 +42,22 @@ end
 %w(work temp).each do |tomcat_dir|
   directory ::File.join(node['artifactory']['catalina_base'], tomcat_dir) do
     owner node['artifactory']['user']
+    group node['artifactory']['group']
     mode 00755
   end
 end
 
 directory node['artifactory']['log_dir'] do
   owner node['artifactory']['user']
+  group node['artifactory']['group']
   mode 00755
 end
 
 ark 'artifactory' do
   url node['artifactory']['zip_url']
   checksum node['artifactory']['zip_checksum']
+  owner node['artifactory']['user']
+  group node['artifactory']['group']
   action :install
 end
 


### PR DESCRIPTION
Without these changes Artifactory fails to start, because it can not unpack WAR file.